### PR TITLE
feat: upgrade react-router to 7.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,20 +6,20 @@
     "": {
       "name": "youtube-jukebox",
       "dependencies": {
-        "@react-router/node": "^7.5.2",
-        "@react-router/serve": "^7.5.2",
+        "@react-router/node": "^7.6.2",
+        "@react-router/serve": "^7.6.2",
         "@types/react-youtube": "^7.6.2",
         "firebase": "^11.8.1",
         "isbot": "^5.1.17",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
-        "react-router": "^7.5.2",
+        "react-router": "^7.6.2",
         "react-youtube": "^10.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.1",
-        "@react-router/dev": "^7.5.2",
+        "@react-router/dev": "^7.6.2",
         "@tailwindcss/vite": "^4.1.5",
         "@types/node": "^22",
         "@types/react": "^19.0.1",
@@ -3291,9 +3291,9 @@
       "license": "MIT"
     },
     "node_modules/@react-router/dev": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.5.2.tgz",
-      "integrity": "sha512-5gam2/IhcBUNoLa0k/Mlk/HZBmkYXn0uGycmz9vi0QCQROX8x3Wbq4W2D0/vnjF3ol6rlp4Sp1GQCWGgqgUwOQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.6.2.tgz",
+      "integrity": "sha512-BuG83Ug2C/P+zMYErTz/KKuXoxbOefh3oR66r13XWG9txwooC9nt2QDt2u8yt7Eo/9BATnx+TmXnOHEWqMyB8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3306,7 +3306,7 @@
         "@babel/traverse": "^7.23.2",
         "@babel/types": "^7.22.5",
         "@npmcli/package-json": "^4.0.1",
-        "@react-router/node": "7.5.2",
+        "@react-router/node": "7.6.2",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
         "chokidar": "^4.0.0",
@@ -3323,7 +3323,7 @@
         "semver": "^7.3.7",
         "set-cookie-parser": "^2.6.0",
         "valibot": "^0.41.0",
-        "vite-node": "3.0.0-beta.2"
+        "vite-node": "^3.1.4"
       },
       "bin": {
         "react-router": "bin.js"
@@ -3332,8 +3332,8 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.5.2",
-        "react-router": "^7.5.2",
+        "@react-router/serve": "^7.6.2",
+        "react-router": "^7.6.2",
         "typescript": "^5.1.0",
         "vite": "^5.1.0 || ^6.0.0",
         "wrangler": "^3.28.2 || ^4.0.0"
@@ -3351,19 +3351,19 @@
       }
     },
     "node_modules/@react-router/express": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.5.2.tgz",
-      "integrity": "sha512-jdsDQYTiKQM8afP1Xyu6DWrFOLK4CEpNfV56mXlQJ2DqyrNzm4j7A/6PxSFA+5SdCehxTyJQQ6fA4g/1x/+iZg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.6.2.tgz",
+      "integrity": "sha512-b1XwP2ZknWG6yNl1aEAJ+yx0Alk85+iLk5y521MOhh2lCKPNyFOuX4Gw8hI3E4IXgDEPqiZ+lipmrIb7XkLNZQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/node": "7.5.2"
+        "@react-router/node": "7.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "express": "^4.17.1 || ^5",
-        "react-router": "7.5.2",
+        "react-router": "7.6.2",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3373,9 +3373,9 @@
       }
     },
     "node_modules/@react-router/node": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.5.2.tgz",
-      "integrity": "sha512-dFMPpPgRMYI4Lvi+9fPs8FjsIto/Z0DCrpAw85+mBKeluLvPOLQ9XhlhCu0G850ZBWiHIm9eReWFLnPWo5+tZg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.6.2.tgz",
+      "integrity": "sha512-KrxfnfJVU1b+020VKemkxpc7ssItsAL8MOJthcoGwPyKwrgovdwc+8NKJUqw3P7yk/Si0ZmVh9QYAzi9qF96dg==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
@@ -3387,7 +3387,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.5.2",
+        "react-router": "7.6.2",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3397,13 +3397,13 @@
       }
     },
     "node_modules/@react-router/serve": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.5.2.tgz",
-      "integrity": "sha512-CNUHldEXGEkUiXhGbszHctzJn7iWzHxf2fkX9pUCA9I/v4WFtjO7JIgqL3wGr7Cjr6Zgh5PT5CdL9cQakHTvOQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.6.2.tgz",
+      "integrity": "sha512-VTdvB8kdZEtYeQML9TFJiIZnPefv94LfmLx5qQ0SJSesel/hQolnfpWEkLJ9WtBO+/10CulAvg6y5UwiceUFTQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/express": "7.5.2",
-        "@react-router/node": "7.5.2",
+        "@react-router/express": "7.6.2",
+        "@react-router/node": "7.6.2",
         "compression": "^1.7.4",
         "express": "^4.19.2",
         "get-port": "5.1.1",
@@ -3417,7 +3417,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.5.2"
+        "react-router": "7.6.2"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6238,9 +6238,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10715,14 +10715,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.2.tgz",
-      "integrity": "sha512-9Rw8r199klMnlGZ8VAsV/I8WrIF6IyJ90JQUdboupx1cdkgYqwnrYjH+I/nY/7cA1X5zia4mDJqH36npP7sxGQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -12082,12 +12081,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -12335,9 +12328,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -12634,17 +12627,17 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.0-beta.2.tgz",
-      "integrity": "sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.3.tgz",
+      "integrity": "sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0 || ^6.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -12655,6 +12648,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -16,20 +16,20 @@
     ]
   },
   "dependencies": {
-    "@react-router/node": "^7.5.2",
-    "@react-router/serve": "^7.5.2",
+    "@react-router/node": "^7.6.2",
+    "@react-router/serve": "^7.6.2",
     "@types/react-youtube": "^7.6.2",
     "firebase": "^11.8.1",
     "isbot": "^5.1.17",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "react-router": "^7.5.2",
+    "react-router": "^7.6.2",
     "react-youtube": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",
-    "@react-router/dev": "^7.5.2",
+    "@react-router/dev": "^7.6.2",
     "@tailwindcss/vite": "^4.1.5",
     "@types/node": "^22",
     "@types/react": "^19.0.1",


### PR DESCRIPTION
Upgrades react-router and related packages from 7.5.2 to 7.6.2.

This is a patch release with no breaking changes. All existing React Router v7 patterns in the codebase remain compatible.

## Changes
- Updated react-router: 7.5.2 → 7.6.2
- Updated @react-router/node: 7.5.2 → 7.6.2
- Updated @react-router/serve: 7.5.2 → 7.6.2
- Updated @react-router/dev: 7.5.2 → 7.6.2

Resolves #45